### PR TITLE
Use basestring to allow unicode and str types for python 2.x

### DIFF
--- a/garlicconfig/fields/__init__.py
+++ b/garlicconfig/fields/__init__.py
@@ -112,7 +112,10 @@ class StringField(ConfigField):
 
     def validate(self, value):
         super(StringField, self).validate(value)
-        assert_value_type(value, six.text_type, self.name)
+        try:
+            assert_value_type(value, basestring, self.name)
+        except NameError:
+            assert_value_type(value, six.text_type, self.name)
         if self.choices and value not in self.choices:
             raise ValidationError("Value '{given}' for '{key}' is not accepted. Choices are '{choices}'".format(
                 given=value,


### PR DESCRIPTION
## What is this pull request for?
- [X] Bug Fix
- [ ] New Feature
- [ ] Improvement

## Why does GarlicConfig need this pull request?
Unicode and string types both need to be supported for Python 2.X
