### PR TITLE
FIX: String decoding issues

### DIFF
--- a/garlicconfig/exceptions.pyx
+++ b/garlicconfig/exceptions.pyx
@@ -24,4 +24,4 @@ cdef extern from "error_handling_utility.cpp":
 
 cdef int raise_py_error() except *:
     cdef vector[string] ex_info = get_native_error()
-    raise error_map[ex_info[0]](ex_info[1])
+    raise error_map[ex_info[0].decode('utf-8')](ex_info[1].decode('utf-8'))

--- a/garlicconfig/layer.pyx
+++ b/garlicconfig/layer.pyx
@@ -71,7 +71,7 @@ cdef class GarlicValue(object):
     @staticmethod
     cdef map_value(const shared_ptr[LayerValue]& value):
         if deref(value).is_string():
-            return deref(value).get_string().decode("utf-8")
+            return deref(value).get_string().decode('utf-8')
         elif deref(value).is_bool():
             return deref(value).get_bool()
         elif deref(value).is_int():


### PR DESCRIPTION
## What is this pull request for?
- [X] Bug Fix
- [ ] New Feature
- [ ] Improvement

## Why does GarlicConfig need this pull request?
The way exceptions are handled in `garlicconfig` requires passing a string demonstrating the type of the exception and its message from C++ to Python, doing this requires hash map look up which is where this bug occurs. The C++ response is in bytes and the Python dictionary is in uncode so we have to convert the text.
