### PR TITLE
RDL-4156: Add Windows Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
         environment:
             PYTHON_BIN: python3
 
-    test-win32-py37-x64: &test-win32
+    test-win32-py37-x64: &test-win32-x64
         executor: win/default
         environment:
             PYTHON_NAME: python
@@ -192,35 +192,46 @@ jobs:
                     python tests.py
 
     test-win32-py36-x64:
-        <<: *test-win32
+        <<: *test-win32-x64
         environment:
             PYTHON_NAME: python
             PYTHON_VERSION: 3.6.8
             ARCH: x64
 
     test-win32-py35-x64:
-        <<: *test-win32
+        <<: *test-win32-x64
         environment:
             PYTHON_NAME: python
             PYTHON_VERSION: 3.5.4
             ARCH: x64
 
-    test-win32-py37-x86:
-        <<: *test-win32
+    test-win32-py37-x86: &test-win32-x86
+        <<: *test-win32-x64
         environment:
             PYTHON_NAME: pythonx86
             PYTHON_VERSION: 3.7.5
             ARCH: x86
+        steps:
+            - checkout
+            - run: *install_win32_python
+            - restore_cache:
+                keys:
+                - cget-v2-x86-{{ arch }}-{{ checksum "requirements.txt" }}
+            - run: *install_win32_native_libs
+            - save_cache:
+                    key: cget-v2-x86-{{ arch }}-{{ checksum "requirements.txt" }}
+                    paths: ["cget"]
+            - run: *run_win32_tests
 
     test-win32-py36-x86:
-        <<: *test-win32
+        <<: *test-win32-x86
         environment:
             PYTHON_NAME: pythonx86
             PYTHON_VERSION: 3.6.8
             ARCH: x86
 
     test-win32-py35-x86:
-        <<: *test-win32
+        <<: *test-win32-x86
         environment:
             PYTHON_NAME: pythonx86
             PYTHON_VERSION: 3.5.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,6 @@ jobs:
         environment:
             PYTHON_NAME: python
             PYTHON_VERSION: 3.7.5
-            ARCH: x64
         steps:
             - checkout
             - run: &install_win32_python
@@ -184,12 +183,12 @@ jobs:
             - restore_cache:
                 keys:
                 - cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
-            - run: &install_win32_native_libs
-                name: "Resolve Native Dependencies"
+            - run: &install_win32_x64_native_libs
+                name: "Resolve Native Dependencies x64"
                 command: |
                     ~\garlic\Scripts\activate.ps1
                     cget init --std=c++ --static
-                    cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt
+                    cget install -DCMAKE_GENERATOR_PLATFORM=x64 --file=native_requirements.txt
             - save_cache:
                     key: cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
                     paths: ["cget"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,8 +175,8 @@ jobs:
                 command: |
                     cd ~
                     nuget install $env:PYTHON_NAME -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
-                    .\python\tools\python.exe -m pip install virtualenv
-                    .\python\tools\python.exe -m virtualenv garlic
+                    .\$env:PYTHON_NAME\tools\python.exe -m pip install virtualenv
+                    .\$env:PYTHON_NAME\tools\python.exe -m virtualenv garlic
                     .\garlic\Scripts\activate.ps1
                     cd project
                     pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
         environment:
             PYTHON_BIN: python3
 
-    test-win32-py37-x64: &test-win32-x64
+    test-win32-py37-x64: &test-win32
         executor: win/default
         environment:
             PYTHON_NAME: python
@@ -192,25 +192,39 @@ jobs:
                     python tests.py
 
     test-win32-py36-x64:
-        <<: *test-win32-x64
+        <<: *test-win32
         environment:
             PYTHON_NAME: python
             PYTHON_VERSION: 3.6.8
             ARCH: x64
 
     test-win32-py35-x64:
-        <<: *test-win32-x64
+        <<: *test-win32
         environment:
             PYTHON_NAME: python
             PYTHON_VERSION: 3.5.4
             ARCH: x64
 
-    test-win32-py27-x64:
-        <<: *test-win32-x64
+    test-win32-py37-x86:
+        <<: *test-win32
         environment:
-            PYTHON_NAME: python2
-            PYTHON_VERSION: 2.7.17
-            ARCH: x64
+            PYTHON_NAME: pythonx86
+            PYTHON_VERSION: 3.7.5
+            ARCH: x86
+
+    test-win32-py36-x86:
+        <<: *test-win32
+        environment:
+            PYTHON_NAME: pythonx86
+            PYTHON_VERSION: 3.6.8
+            ARCH: x86
+
+    test-win32-py35-x86:
+        <<: *test-win32
+        environment:
+            PYTHON_NAME: pythonx86
+            PYTHON_VERSION: 3.5.4
+            ARCH: x86
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
 
 aliases:
     - &restore_cache
@@ -160,19 +163,57 @@ jobs:
         environment:
             PYTHON_BIN: python3
 
+    test-win32-py37-x64:
+        executor: win/default
+        environment:
+            PYTHON_NAME: python
+            PYTHON_VERSION: 3.7.5
+            ARCH: x64
+        steps:
+            - checkout
+            - run: &install_win32_python
+                name: "Install Python and Install Dependencies"
+                command: |
+                    cd ~
+                    nuget install $env:PYTHON_NAME -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
+                    .\python\tools\python.exe -m pip install virtualenv
+                    .\python\tools\python.exe -m pip virtualenv garlic
+                    .\garlic\Scripts\activate.ps1
+                    pip install -r requirements.txt
+            - restore_cache:
+                keys:
+                - cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
+            - run: &install_win32_native_libs
+                name: "Resolve Native Dependencies"
+                command: |
+                    ~\garlic\Scripts\activate.ps1
+                    cget init --std=c++ --static
+                    cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt
+            - save_cache:
+                    key: cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
+                    paths: ["cget"]
+            - run: &run_win32_tests
+                name: "Run Tests for Windows"
+                command: |
+                    ~\garlic\Scripts\activate.ps1
+                    python setup.py install
+                    cd tests
+                    python tests.py
+
 workflows:
     version: 2
     pr-checks:
         jobs:
-            - lint-checks
-            - test-linux-py27m
-            - test-linux-py27mu
-            - test-linux-py34m
-            - test-linux-py35m
-            - test-linux-py36m
-            - test-linux-py37m
-            - test-mac-py27
-            - test-mac-py37
+            - test-win32-py37-x64
+            #- lint-checks
+            #- test-linux-py27m
+            #- test-linux-py27mu
+            #- test-linux-py34m
+            #- test-linux-py35m
+            #- test-linux-py36m
+            #- test-linux-py37m
+            #- test-mac-py27
+            #- test-mac-py37
             - dist-linux:
                 filters:
                   tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,12 +176,12 @@ jobs:
                 command: .circleci\install_python.ps1
             - restore_cache:
                 keys:
-                - cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
+                - cget-v3-x64-{{ arch }}-{{ checksum "requirements.txt" }}
             - run: &install_win32_native_libs
                 name: "Resolve Native Dependencies x64"
                 command: .circleci\install_libs.ps1
             - save_cache:
-                    key: cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
+                    key: cget-v3-x64-{{ arch }}-{{ checksum "requirements.txt" }}
                     paths: ["cget"]
             - run: &run_win32_tests
                 name: "Run Tests for Windows"
@@ -210,16 +210,15 @@ jobs:
         environment:
             PYTHON_NAME: pythonx86
             PYTHON_VERSION: 3.7.5
-            ARCH: x86
         steps:
             - checkout
             - run: *install_win32_python
             - restore_cache:
                 keys:
-                - cget-v2-x86-{{ arch }}-{{ checksum "requirements.txt" }}
+                - cget-v3-x86-{{ arch }}-{{ checksum "requirements.txt" }}
             - run: *install_win32_native_libs
             - save_cache:
-                    key: cget-v2-x86-{{ arch }}-{{ checksum "requirements.txt" }}
+                    key: cget-v3-x86-{{ arch }}-{{ checksum "requirements.txt" }}
                     paths: ["cget"]
             - run: *run_win32_tests
 
@@ -228,14 +227,12 @@ jobs:
         environment:
             PYTHON_NAME: pythonx86
             PYTHON_VERSION: 3.6.8
-            ARCH: x86
 
     test-win32-py35-x86:
         <<: *test-win32-x86
         environment:
             PYTHON_NAME: pythonx86
             PYTHON_VERSION: 3.5.4
-            ARCH: x86
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,9 @@ workflows:
     version: 2
     pr-checks:
         jobs:
-            - test-win32-py27-x64
+            - test-win32-py35-x86
+            - test-win32-py36-x86
+            - test-win32-py37-x86
             - test-win32-py35-x64
             - test-win32-py36-x64
             - test-win32-py37-x64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ jobs:
         environment:
             PYTHON_NAME: python
             PYTHON_VERSION: 3.7.5
+            ARCH: x64
         steps:
             - checkout
             - run: &install_win32_python
@@ -183,12 +184,12 @@ jobs:
             - restore_cache:
                 keys:
                 - cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
-            - run: &install_win32_x64_native_libs
+            - run: &install_win32_native_libs
                 name: "Resolve Native Dependencies x64"
                 command: |
                     ~\garlic\Scripts\activate.ps1
                     cget init --std=c++ --static
-                    cget install -DCMAKE_GENERATOR_PLATFORM=x64 --file=native_requirements.txt
+                    cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt
             - save_cache:
                     key: cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
                     paths: ["cget"]
@@ -203,18 +204,23 @@ jobs:
     test-win32-py36-x64:
         <<: *test-win32-x64
         environment:
+            PYTHON_NAME: python
             PYTHON_VERSION: 3.6.8
+            ARCH: x64
 
     test-win32-py35-x64:
         <<: *test-win32-x64
         environment:
+            PYTHON_NAME: python
             PYTHON_VERSION: 3.5.4
+            ARCH: x64
 
     test-win32-py27-x64:
         <<: *test-win32-x64
         environment:
             PYTHON_NAME: python2
             PYTHON_VERSION: 2.7.17
+            ARCH: x64
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,23 +173,13 @@ jobs:
             - checkout
             - run: &install_win32_python
                 name: "Install Python and Install Dependencies"
-                command: |
-                    cd ~
-                    nuget install $env:PYTHON_NAME -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
-                    .\$env:PYTHON_NAME\tools\python.exe -m pip install virtualenv
-                    .\$env:PYTHON_NAME\tools\python.exe -m virtualenv garlic
-                    .\garlic\Scripts\activate.ps1
-                    cd project
-                    pip install -r requirements.txt
+                command: .circleci\install_python.ps1
             - restore_cache:
                 keys:
                 - cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
             - run: &install_win32_native_libs
                 name: "Resolve Native Dependencies x64"
-                command: |
-                    ~\garlic\Scripts\activate.ps1
-                    cget init --std=c++ --static
-                    cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt
+                command: .circleci\install_libs.ps1
             - save_cache:
                     key: cget-v2-x64-{{ arch }}-{{ checksum "requirements.txt" }}
                     paths: ["cget"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
                     cd ~
                     nuget install $env:PYTHON_NAME -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
                     .\python\tools\python.exe -m pip install virtualenv
-                    .\python\tools\python.exe -m pip virtualenv garlic
+                    .\python\tools\python.exe -m virtualenv garlic
                     .\garlic\Scripts\activate.ps1
                     pip install -r requirements.txt
             - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
                 keys:
                 - cget-v3-x64-{{ arch }}-{{ checksum "requirements.txt" }}
             - run: &install_win32_native_libs
-                name: "Resolve Native Dependencies x64"
+                name: "Resolve Native Dependencies"
                 command: .circleci\install_libs.ps1
             - save_cache:
                     key: cget-v3-x64-{{ arch }}-{{ checksum "requirements.txt" }}
@@ -234,6 +234,72 @@ jobs:
             PYTHON_NAME: pythonx86
             PYTHON_VERSION: 3.5.4
 
+    dist-win32-py37-x64: &dist-win32-x64
+        <<: *test-win32-x64
+        steps:
+            - checkout
+            - run: *install_win32_python
+            - restore_cache:
+                keys:
+                - cget-v3-x64-{{ arch }}-{{ checksum "requirements.txt" }}
+            - run: *install_win32_native_libs
+            - save_cache:
+                    key: cget-v3-x64-{{ arch }}-{{ checksum "requirements.txt" }}
+                    paths: ["cget"]
+            - run: &publish_win32
+                name: "Build Package And Submit"
+                command: |
+                    ~\garlic\Scripts\activate.ps1
+                    python setup.py bdist_wheel
+                    pip install twine
+                    twine upload wheelhouse/*
+
+    dist-win32-py36-x64:
+        <<: *dist-win32-x64
+        environment:
+            PYTHON_NAME: python
+            PYTHON_VERSION: 3.6.8
+            ARCH: x64
+
+    dist-win32-py35-x64:
+        <<: *dist-win32-x64
+        environment:
+            PYTHON_NAME: python
+            PYTHON_VERSION: 3.5.4
+            ARCH: x64
+
+    dist-win32-py37-x86: &dist-win32-x86
+        <<: *test-win32-x86
+        steps:
+            - checkout
+            - run: *install_win32_python
+            - restore_cache:
+                keys:
+                - cget-v3-x86-{{ arch }}-{{ checksum "requirements.txt" }}
+            - run: *install_win32_native_libs
+            - save_cache:
+                    key: cget-v3-x86-{{ arch }}-{{ checksum "requirements.txt" }}
+                    paths: ["cget"]
+            - run: &publish_win32
+                name: "Build Package And Submit"
+                command: |
+                    ~\garlic\Scripts\activate.ps1
+                    python setup.py bdist_wheel
+                    pip install twine
+                    twine upload wheelhouse/*
+
+    dist-win32-py36-x86:
+        <<: *dist-win32-x86
+        environment:
+            PYTHON_NAME: pythonx86
+            PYTHON_VERSION: 3.6.8
+
+    dist-win32-py35-x86:
+        <<: *dist-win32-x86
+        environment:
+            PYTHON_NAME: pythonx86
+            PYTHON_VERSION: 3.5.4
+
 workflows:
     version: 2
     pr-checks:
@@ -244,15 +310,15 @@ workflows:
             - test-win32-py35-x64
             - test-win32-py36-x64
             - test-win32-py37-x64
-            #- lint-checks
-            #- test-linux-py27m
-            #- test-linux-py27mu
-            #- test-linux-py34m
-            #- test-linux-py35m
-            #- test-linux-py36m
-            #- test-linux-py37m
-            #- test-mac-py27
-            #- test-mac-py37
+            - lint-checks
+            - test-linux-py27m
+            - test-linux-py27mu
+            - test-linux-py34m
+            - test-linux-py35m
+            - test-linux-py36m
+            - test-linux-py37m
+            - test-mac-py27
+            - test-mac-py37
             - dist-linux:
                 filters:
                   tags:
@@ -266,6 +332,42 @@ workflows:
                   branches:
                     ignore: /.*/
             - dist-mac-py37:
+                filters:
+                  tags:
+                    only: /^[0-9][.][0-9][.][0-9]$/
+                  branches:
+                    ignore: /.*/
+            - dist-win32-py37-x64:
+                filters:
+                  tags:
+                    only: /^[0-9][.][0-9][.][0-9]$/
+                  branches:
+                    ignore: /.*/
+            - dist-win32-py36-x64:
+                filters:
+                  tags:
+                    only: /^[0-9][.][0-9][.][0-9]$/
+                  branches:
+                    ignore: /.*/
+            - dist-win32-py35-x64:
+                filters:
+                  tags:
+                    only: /^[0-9][.][0-9][.][0-9]$/
+                  branches:
+                    ignore: /.*/
+            - dist-win32-py37-x86:
+                filters:
+                  tags:
+                    only: /^[0-9][.][0-9][.][0-9]$/
+                  branches:
+                    ignore: /.*/
+            - dist-win32-py36-x86:
+                filters:
+                  tags:
+                    only: /^[0-9][.][0-9][.][0-9]$/
+                  branches:
+                    ignore: /.*/
+            - dist-win32-py35-x86:
                 filters:
                   tags:
                     only: /^[0-9][.][0-9][.][0-9]$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
         environment:
             PYTHON_BIN: python3
 
-    test-win32-py37-x64:
+    test-win32-py37-x64: &test-win32-x64
         executor: win/default
         environment:
             PYTHON_NAME: python
@@ -200,10 +200,29 @@ jobs:
                     cd tests
                     python tests.py
 
+    test-win32-py36-x64:
+        <<: *test-win32-x64
+        environment:
+            PYTHON_VERSION: 3.6.8
+
+    test-win32-py35-x64:
+        <<: *test-win32-x64
+        environment:
+            PYTHON_VERSION: 3.5.4
+
+    test-win32-py27-x64:
+        <<: *test-win32-x64
+        environment:
+            PYTHON_NAME: python2
+            PYTHON_VERSION: 2.7.17
+
 workflows:
     version: 2
     pr-checks:
         jobs:
+            - test-win32-py27-x64
+            - test-win32-py35-x64
+            - test-win32-py36-x64
             - test-win32-py37-x64
             #- lint-checks
             #- test-linux-py27m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
                     .\python\tools\python.exe -m pip install virtualenv
                     .\python\tools\python.exe -m virtualenv garlic
                     .\garlic\Scripts\activate.ps1
+                    cd project
                     pip install -r requirements.txt
             - restore_cache:
                 keys:

--- a/.circleci/install_libs.ps1
+++ b/.circleci/install_libs.ps1
@@ -1,0 +1,3 @@
+~\garlic\Scripts\activate.ps1
+cget init --std=c++ --static
+cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt

--- a/.circleci/install_libs.ps1
+++ b/.circleci/install_libs.ps1
@@ -1,3 +1,3 @@
 ~\garlic\Scripts\activate.ps1
 cget init --std=c++ --static
-cget install -DCMAKE_GENERATOR_PLATFORM=$ARCH --file=native_requirements.txt
+cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt

--- a/.circleci/install_libs.ps1
+++ b/.circleci/install_libs.ps1
@@ -1,3 +1,7 @@
 ~\garlic\Scripts\activate.ps1
 cget init --std=c++ --static
-cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt
+if ($env:ARCH) {
+	cget install -DCMAKE_GENERATOR_PLATFORM=x64 --file=native_requirements.txt
+} else {
+	cget install --file=native_requirements.txt
+}

--- a/.circleci/install_libs.ps1
+++ b/.circleci/install_libs.ps1
@@ -1,3 +1,3 @@
 ~\garlic\Scripts\activate.ps1
 cget init --std=c++ --static
-cget install -DCMAKE_GENERATOR_PLATFORM=$env:ARCH --file=native_requirements.txt
+cget install -DCMAKE_GENERATOR_PLATFORM=$ARCH --file=native_requirements.txt

--- a/.circleci/install_python.ps1
+++ b/.circleci/install_python.ps1
@@ -1,0 +1,7 @@
+cd ~
+nuget install $env:PYTHON_NAME -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
+$env:PYTHON_NAME\tools\python.exe -m pip install virtualenv
+$env:PYTHON_NAME\tools\python.exe -m virtualenv garlic
+garlic\Scripts\activate.ps1
+cd project
+pip install -r requirements.txt

--- a/.circleci/install_python.ps1
+++ b/.circleci/install_python.ps1
@@ -1,7 +1,7 @@
 cd ~
-nuget install $env:PYTHON_NAME -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
-$env:PYTHON_NAME\tools\python.exe -m pip install virtualenv
-$env:PYTHON_NAME\tools\python.exe -m virtualenv garlic
+nuget install $PYTHON_NAME -Version $PYTHON_VERSION -ExcludeVersion -OutputDirectory .
+$PYTHON_NAME\tools\python.exe -m pip install virtualenv
+$PYTHON_NAME\tools\python.exe -m virtualenv garlic
 garlic\Scripts\activate.ps1
 cd project
 pip install -r requirements.txt

--- a/.circleci/install_python.ps1
+++ b/.circleci/install_python.ps1
@@ -1,7 +1,7 @@
 cd ~
-nuget install $PYTHON_NAME -Version $PYTHON_VERSION -ExcludeVersion -OutputDirectory .
-$PYTHON_NAME\tools\python.exe -m pip install virtualenv
-$PYTHON_NAME\tools\python.exe -m virtualenv garlic
+nuget install $env:PYTHON_NAME -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
+& "$env:PYTHON_NAME\tools\python.exe" -m pip install virtualenv
+& "$env:PYTHON_NAME\tools\python.exe" -m virtualenv garlic
 garlic\Scripts\activate.ps1
 cd project
 pip install -r requirements.txt

--- a/native_requirements.txt
+++ b/native_requirements.txt
@@ -1,1 +1,1 @@
-infoscout/garlicconfig-core@1.0.3
+infoscout/garlicconfig-core@1.0.4


### PR DESCRIPTION
## What is this pull request for?
- [ ] Bug Fix
- [ ] New Feature
- [X] Improvement

## Why does GarlicConfig need this pull request?
We're adding support for Windows wheels. this will allow Python 3.5, Python 3.6 and Python 3.7 users to use garlicconfig package on Windows in either x64 or x86 architectures.

## Short Description
We need windows support.