### PR TITLE
RDL-4270: Add 'field_order' attribute to models.

### DIFF
--- a/garlicconfig/models.py
+++ b/garlicconfig/models.py
@@ -37,6 +37,8 @@ class ModelMetaClass(type):
 @six.add_metaclass(ModelMetaClass)
 class ConfigModel(object):
 
+    field_order = None  # Optional: how fields should be ordered when displayed
+
     def __init__(self):
         for field_name in self.__meta__.fields:
             value = getattr(self, field_name)
@@ -146,9 +148,13 @@ class ModelField(ConfigField):
         return self.model_class.from_dict(value)
 
     def __extra_desc__(self):
+        name = self.model_class.__name__
+        fields = self.model_class.get_model_desc_dict()
+        field_order = self.model_class.field_order or list(fields)
         return {
             'model_info': {
-                'name': self.model_class.__name__,
-                'fields': self.model_class.get_model_desc_dict(),
+                'name': name,
+                'fields': fields,
+                'field_order': field_order,
             }
         }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -259,9 +259,10 @@ class TestConfigModel(unittest.TestCase):
         with self.assertRaises(ValidationError):
             loaded_config.validate()
 
-    def test_model_desc(self):
+    def test_model_desc_wo_field_order(self):
         class KidConfig(ConfigModel):
             name = StringField(name='First Name', nullable=False, default='Sam')
+            age = IntegerField(domain=(0, 20))
 
         class ParentConfig(ConfigModel):
             name = StringField(name='First Name', desc='Enter your first name', nullable=False, default='Peter')
@@ -345,8 +346,245 @@ class TestConfigModel(unittest.TestCase):
                                             'nullable': False,
                                             'default': 'Sam'
                                         }
+                                    },
+                                    'age': {
+                                        'type': 'IntegerField',
+                                        'name': 'age',
+                                        'desc': None,
+                                        'extra': {
+                                            'nullable': True,
+                                            'default': None,
+                                            'domain': (0, 20)
+                                        }
                                     }
-                                }
+                                },
+                                'field_order': list(KidConfig.__meta__.fields)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        expected_end_result_json = json.dumps(expected_end_result, sort_keys=True)
+        actual_result_json = json.dumps(ParentConfig.get_model_desc_dict(), sort_keys=True)
+        self.assertEqual(actual_result_json, expected_end_result_json)
+
+    def test_model_desc_w_field_order_1(self):
+        class KidConfig(ConfigModel):
+            field_order = ['name', 'age']
+
+            name = StringField(name='First Name', nullable=False, default='Sam')
+            age = IntegerField(domain=(0, 20))
+
+        class ParentConfig(ConfigModel):
+            name = StringField(name='First Name', desc='Enter your first name', nullable=False, default='Peter')
+            status = StringField(desc='Whats your status?', choices=('Good', 'Bad', 'Indifferent'))
+            age = IntegerField(domain=(21, 150))
+            nick_names = ArrayField(StringField(), name='Nick Names', nullable=False, default=['No Nick Name'])
+            kids = ArrayField(ModelField(KidConfig))
+
+        expected_end_result = {
+            'name': {
+                'type': 'StringField',
+                'name': 'First Name',
+                'desc': 'Enter your first name',
+                'extra': {
+                    'nullable': False,
+                    'default': 'Peter',
+                }
+            },
+            'status': {
+                'type': 'StringField',
+                'name': 'status',
+                'desc': 'Whats your status?',
+                'extra': {
+                    'choices': ('Good', 'Bad', 'Indifferent',),
+                    'nullable': True,
+                    'default': None,
+                }
+            },
+            'age': {
+                'type': 'IntegerField',
+                'name': 'age',
+                'desc': None,
+                'extra': {
+                    'nullable': True,
+                    'default': None,
+                    'domain': (21, 150)
+                }
+            },
+            'nick_names': {
+                'type': 'ArrayField',
+                'name': 'Nick Names',
+                'desc': None,
+                'extra': {
+                    'nullable': False,
+                    'default': ['No Nick Name'],
+                    'element_info': {
+                        'type': 'StringField',
+                        'name': 'StringField',
+                        'desc': None,
+                        'extra': {
+                            'nullable': True,
+                            'default': None,
+                        }
+                    }
+                }
+            },
+            'kids': {
+                'type': 'ArrayField',
+                'name': 'kids',
+                'desc': None,
+                'extra': {
+                    'nullable': True,
+                    'default': None,
+                    'element_info': {
+                        'type': 'ModelField',
+                        'name': 'ModelField',
+                        'desc': None,
+                        'extra': {
+                            'nullable': True,
+                            'default': {
+                                'name': 'Sam'
+                            },
+                            'model_info': {
+                                'name': 'KidConfig',
+                                'fields': {
+                                    'name': {
+                                        'type': 'StringField',
+                                        'name': 'First Name',
+                                        'desc': None,
+                                        'extra': {
+                                            'nullable': False,
+                                            'default': 'Sam'
+                                        }
+                                    },
+                                    'age': {
+                                        'type': 'IntegerField',
+                                        'name': 'age',
+                                        'desc': None,
+                                        'extra': {
+                                            'nullable': True,
+                                            'default': None,
+                                            'domain': (0, 20)
+                                        }
+                                    }
+                                },
+                                'field_order': ['name', 'age']
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        expected_end_result_json = json.dumps(expected_end_result, sort_keys=True)
+        actual_result_json = json.dumps(ParentConfig.get_model_desc_dict(), sort_keys=True)
+        self.assertEqual(actual_result_json, expected_end_result_json)
+
+    def test_model_desc_w_field_order_2(self):
+        class KidConfig(ConfigModel):
+            field_order = ['age', 'name']
+
+            name = StringField(name='First Name', nullable=False, default='Sam')
+            age = IntegerField(domain=(0, 20))
+
+        class ParentConfig(ConfigModel):
+            name = StringField(name='First Name', desc='Enter your first name', nullable=False, default='Peter')
+            status = StringField(desc='Whats your status?', choices=('Good', 'Bad', 'Indifferent'))
+            age = IntegerField(domain=(21, 150))
+            nick_names = ArrayField(StringField(), name='Nick Names', nullable=False, default=['No Nick Name'])
+            kids = ArrayField(ModelField(KidConfig))
+
+        expected_end_result = {
+            'name': {
+                'type': 'StringField',
+                'name': 'First Name',
+                'desc': 'Enter your first name',
+                'extra': {
+                    'nullable': False,
+                    'default': 'Peter',
+                }
+            },
+            'status': {
+                'type': 'StringField',
+                'name': 'status',
+                'desc': 'Whats your status?',
+                'extra': {
+                    'choices': ('Good', 'Bad', 'Indifferent',),
+                    'nullable': True,
+                    'default': None,
+                }
+            },
+            'age': {
+                'type': 'IntegerField',
+                'name': 'age',
+                'desc': None,
+                'extra': {
+                    'nullable': True,
+                    'default': None,
+                    'domain': (21, 150)
+                }
+            },
+            'nick_names': {
+                'type': 'ArrayField',
+                'name': 'Nick Names',
+                'desc': None,
+                'extra': {
+                    'nullable': False,
+                    'default': ['No Nick Name'],
+                    'element_info': {
+                        'type': 'StringField',
+                        'name': 'StringField',
+                        'desc': None,
+                        'extra': {
+                            'nullable': True,
+                            'default': None,
+                        }
+                    }
+                }
+            },
+            'kids': {
+                'type': 'ArrayField',
+                'name': 'kids',
+                'desc': None,
+                'extra': {
+                    'nullable': True,
+                    'default': None,
+                    'element_info': {
+                        'type': 'ModelField',
+                        'name': 'ModelField',
+                        'desc': None,
+                        'extra': {
+                            'nullable': True,
+                            'default': {
+                                'name': 'Sam'
+                            },
+                            'model_info': {
+                                'name': 'KidConfig',
+                                'fields': {
+                                    'name': {
+                                        'type': 'StringField',
+                                        'name': 'First Name',
+                                        'desc': None,
+                                        'extra': {
+                                            'nullable': False,
+                                            'default': 'Sam'
+                                        }
+                                    },
+                                    'age': {
+                                        'type': 'IntegerField',
+                                        'name': 'age',
+                                        'desc': None,
+                                        'extra': {
+                                            'nullable': True,
+                                            'default': None,
+                                            'domain': (0, 20)
+                                        }
+                                    }
+                                },
+                                'field_order': ['age', 'name']
                             }
                         }
                     }


### PR DESCRIPTION
## What is this pull request for?
- [ ] Bug Fix
- [ ] New Feature
- [X] Improvement

## Why does GarlicConfig need this pull request?
When it comes time to display a model and its fields in some form, it would be useful it the model could dictate what order those fields are to be displayed in.

## Short Description
- Adds an attribute `field_order` on `ConfigModel` which defaults to `None`.
- Adds a key `'field_order'` to the `'extra'` model description which prefers this attribute, but falls back to simply listing the fields in whatever order they are stored in.
